### PR TITLE
Added Binder functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 A home for my interactive data viz slides [currently a work in progress]...
 
 ### Notebook & Slides
-Slides are in this [Jupyter notebook](https://github.com/jessimk/interactive_data_viz/blob/master/Jupyter_Interactive_Data_Viz.ipynb) and can be viewed best with [nbviewer here](https://nbviewer.jupyter.org/github/jessimk/interactive_data_viz/blob/master/Jupyter_Interactive_Data_Viz.ipynb?flush_cache=true) with all of the interactive awesome.
+
+An interactive and executable version of these slides are available in a Jupyter notebook via Binder through the button below:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ttimbers/interactive_data_viz/master?filepath=Jupyter_Interactive_Data_Viz.ipynb)
+
+Source slides are in this [Jupyter notebook](https://github.com/jessimk/interactive_data_viz/blob/master/Jupyter_Interactive_Data_Viz.ipynb) and can also be viewed best with [nbviewer here](https://nbviewer.jupyter.org/github/jessimk/interactive_data_viz/blob/master/Jupyter_Interactive_Data_Viz.ipynb?flush_cache=true).
 
 ### Data
 Data for this presentation is a subset of [Mobi's June 2018 system data](https://www.mobibikes.ca/en/system-data). 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+matplotlib
+seaborn
+plotly
+folium


### PR DESCRIPTION
Viewing the notebook on GitHub or using nbviewer is good, but Binder takes this to the next level. When folks click on the button in your notebook they can (after ~ 3min) have a temporary interactive and executable Jupyter Notebook from your repo. 

All I needed to do to make this work was create a `requirements.txt` file listing the package requirements, and then fill in the info [here](https://mybinder.org/) and follow the instructions to create the button on the README page.  

note - I will cover Binder in my talk, so it might be cool for folks to see you using it too!